### PR TITLE
Quick check on the returnurl parameter for signin. If url is either a…

### DIFF
--- a/src/Volvox.Helios.Web/Controllers/AuthenticationController.cs
+++ b/src/Volvox.Helios.Web/Controllers/AuthenticationController.cs
@@ -11,8 +11,16 @@ namespace Volvox.Helios.Web.Controllers
         {
             var returnUrl = HttpContext.Request.Query["ReturnUrl"].ToString();
 
+            if (
+                   string.IsNullOrWhiteSpace(returnUrl)
+                || !Url.IsLocalUrl(returnUrl)
+                )
+            {
+                returnUrl = "/";
+            }
+
             return Challenge(
-                new AuthenticationProperties {RedirectUri = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl},
+                new AuthenticationProperties {RedirectUri =  returnUrl},
                 "Discord");
         }
 


### PR DESCRIPTION
… non-local, or null or whitespace, returnUrl gets set to "/".

fixes #72 