### PR TITLE
Attempt to fix the streamer role not removing

### DIFF
--- a/src/Volvox.Helios.Core/Modules/StreamerRole/StreamerRoleModule.cs
+++ b/src/Volvox.Helios.Core/Modules/StreamerRole/StreamerRoleModule.cs
@@ -65,7 +65,7 @@ namespace Volvox.Helios.Core.Modules.StreamerRole
                         }
 
                         // Remove user from role.
-                        if (guildUser.Roles.Any(r => r == streamingRole))
+                        if (guildUser.Roles.Any(r => r.Id == streamingRole.Id))
                         {
                             await RemoveUserFromStreamingRole(guildUser, streamingRole);
                         }


### PR DESCRIPTION
The Discord.Net Client is caching things. Previously we compared the role by reference rather than by the primary identifier. This might have caused some inconsistencies when removing roles and would explain why the issue has seemingly been unseen/silent. 